### PR TITLE
fixing error with hardcoded time unit in nc_attributes for om timeseries

### DIFF
--- a/pocean/dsg/timeseries/om.py
+++ b/pocean/dsg/timeseries/om.py
@@ -232,7 +232,7 @@ class OrthogonalMultidimensionalTimeseries(CFDataset):
                 'long_name' : 'station identifier'
             },
             'time': {
-                'units': self.__class__.default_time_unit,
+                'units': self.default_time_unit,
                 'standard_name': 'time',
                 'axis': 'T'
             }

--- a/pocean/dsg/timeseries/om.py
+++ b/pocean/dsg/timeseries/om.py
@@ -232,7 +232,7 @@ class OrthogonalMultidimensionalTimeseries(CFDataset):
                 'long_name' : 'station identifier'
             },
             'time': {
-                'units': 'seconds since 1970-01-01T00:00:00Z',
+                'units': self.__class__.default_time_unit,
                 'standard_name': 'time',
                 'axis': 'T'
             }


### PR DESCRIPTION
I hardcoded the time unit incorrectly, now I'm using `default_time_unit` instead of hardcoding it.