### PR TITLE
--gh-pages-docs is deprecated

### DIFF
--- a/docs/deploy.sh
+++ b/docs/deploy.sh
@@ -6,6 +6,6 @@ if [ "$TRAVIS_PYTHON_VERSION" == "3.5" ]; then
     conda install --file requirements.txt
     sphinx-apidoc -M -f -o api ../pocean ../pocean/tests
     make html
-    doctr deploy --built-docs=_site/html --gh-pages-docs .
+    doctr deploy --built-docs=_site/html .
     cd ..
 fi


### PR DESCRIPTION
Fix `doctr` call for the latest version of `doctr`.

For some reason the `docs` are being deployed at a `docs` folder rather than the root folder of `gh-pages`, making them available at https://pyoceans.github.io/pocean-core/docs/

Was that intentional? Should I fixed it?