### PR TITLE
Split test context

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,10 +1,18 @@
 language: python
-python:
-  - "3.4"
-  - "3.5"
-  - "3.6"
 
 sudo: false
+
+matrix:
+  fast_finish: true
+  include:
+  - python: 3.4
+    env: TEST_TARGET=default
+  - python: 3.5
+    env: TEST_TARGET=default
+  - python: 3.6
+    env: TEST_TARGET=default
+  - python: 3.6
+    env: TEST_TARGET=docs
 
 env:
   global:
@@ -43,8 +51,14 @@ install:
 
 script:
   - set -e
-  - py.test -s -rxs -v
-  - conda install -n root conda-build anaconda-client
-  - conda build conda-recipe --python $TRAVIS_PYTHON_VERSION
-  - conda install pocean-core --use-local
-  - ./docs/deploy.sh
+
+  - if [[ $TEST_TARGET == 'default' ]]; then
+      py.test -s -rxs -v ;
+    fi
+
+  - if [[ $TEST_TARGET == "docs" ]]; then
+      conda install -n root conda-build anaconda-client ;
+      conda build conda-recipe --python $TRAVIS_PYTHON_VERSION ;
+      conda install pocean-core --use-local ;
+      ./docs/deploy.sh ;
+    fi

--- a/docs/deploy.sh
+++ b/docs/deploy.sh
@@ -1,11 +1,9 @@
 #!/bin/bash
 set -ev
 
-if [ "$TRAVIS_PYTHON_VERSION" == "3.5" ]; then
-    cd docs
-    conda install --file requirements.txt
-    sphinx-apidoc -M -f -o api ../pocean ../pocean/tests
-    make html
-    doctr deploy --built-docs=_site/html .
-    cd ..
-fi
+cd docs
+conda install --file requirements.txt
+sphinx-apidoc -M -f -o api ../pocean ../pocean/tests
+make html
+doctr deploy --built-docs=_site/html .
+cd ..


### PR DESCRIPTION
@kwilcox for some reason the Python 3.5 test is failing on [`master`](https://travis-ci.org/pyoceans/pocean-core/jobs/216960187) and that is preventing the docs from being deployed.

This PR should help us with that.