### PR TITLE
Use only conda-forge

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -36,7 +36,6 @@ before_install:
   # Add 3rd party channels
   # ------------------------------------
   - conda config --add channels conda-forge
-  - conda config --add channels axiom-data-science
 
   # Create our environment
   # ------------------------------------
@@ -60,6 +59,6 @@ script:
       py.test -s -rxs -v ;
     fi
 
-  - if [[ $TEST_TARGET == "docs" ]]; then
+  - if [[ $TEST_TARGET == 'docs' ]]; then
       ./docs/deploy.sh ;
     fi


### PR DESCRIPTION
@kwilcox using multiple channels can be confusing since we don't know were the dependencies are coming from. For example, I only found out that `conda-forge` was missing `pygc` for Python 3.6 when I tried to package `pocean`.

If we remove `axiom-data-science` here we can catch errors like that earlier and users that rely only `defaults`+`conda-forge` will get a more stable package from `conda-forge`.

PS: I am OK if you want to close this without merging in case you have strong reasons to rely on Axiom's channel, like faster response than `conda-forge` when fixing something, etc.