### PR TITLE
Pandas >= 0.24, allow DAP urls, strict is_mine checks

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -9,6 +9,10 @@ environment:
       CONDA_PY: 36
       CONDA_INSTALL_LOCN: C:\\Miniconda36-x64
 
+    - TARGET_ARCH: x64
+      CONDA_PY: 37
+      CONDA_INSTALL_LOCN: C:\\Miniconda37-x64
+
 platform:
     - x64
 

--- a/conda-recipe/meta.yaml
+++ b/conda-recipe/meta.yaml
@@ -18,14 +18,14 @@ requirements:
     - python
     - netcdf4
     - numpy >=1.14
-    - pandas >=0.21.0
+    - pandas >=0.24,<0.25
     - pygc >=1.2.0
     - python-dateutil
     - pytz
     - shapely
     - simplejson
     - six
-    - cftime ==1.0.1
+    - cftime
 
 test:
   source_files:

--- a/docs/development.rst
+++ b/docs/development.rst
@@ -5,7 +5,14 @@ Create a conda environment
 
 ...code bash
 
-    $ conda create -n pocean35 python=3.5
-    $ source activate pocean35
-    $ conda install --file requirements.txt
+    $ conda create -n pocean37 python=3.7
+    $ source activate pocean37
+    $ conda install --file requirements.txt --file requirements-test.txt
 
+
+Running tests
+-------------
+
+...code bash
+
+    $ pytest

--- a/pocean/cf.py
+++ b/pocean/cf.py
@@ -138,8 +138,8 @@ class CFDataset(EnhancedDataset):
         )))
         return zvars
 
-    def is_valid(self):
-        return self.__class__.is_mine(self)
+    def is_valid(self, *args, **kwargs):
+        return self.__class__.is_mine(self, *args, **kwargs)
 
     def data_vars(self):
         return self.filter_by_attrs(

--- a/pocean/cf.py
+++ b/pocean/cf.py
@@ -7,7 +7,7 @@ from datetime import datetime
 import six
 from six import u as astr
 
-from .utils import all_subclasses
+from .utils import all_subclasses, is_url
 from .dataset import EnhancedDataset
 from . import logger
 
@@ -39,12 +39,14 @@ class CFDataset(EnhancedDataset):
 
         """
 
-        fpath = os.path.realpath(path)
+        if not is_url(path):
+            path = os.path.realpath(path)
+
         subs = list(all_subclasses(cls))
 
         dsg = None
         try:
-            dsg = cls(fpath)
+            dsg = cls(path)
             for klass in subs:
                 logger.debug('Trying {}...'.format(klass.__name__))
                 if hasattr(klass, 'is_mine'):
@@ -59,7 +61,7 @@ class CFDataset(EnhancedDataset):
         subnames = ', '.join([ s.__name__ for s in subs ])
         raise ValueError(
             'Could not open {} as any type of CF Dataset. Tried: {}.'.format(
-                fpath,
+                path,
                 subnames
             )
         )

--- a/pocean/dsg/profile/im.py
+++ b/pocean/dsg/profile/im.py
@@ -39,7 +39,7 @@ class IncompleteMultidimensionalProfile(CFDataset):
     """
 
     @classmethod
-    def is_mine(cls, dsg):
+    def is_mine(cls, dsg, strict=False):
         try:
             pvars = dsg.filter_by_attrs(cf_role='profile_id')
             assert len(pvars) == 1
@@ -73,6 +73,8 @@ class IncompleteMultidimensionalProfile(CFDataset):
                 assert dv.size in [z_dim.size, p_dim.size, z_dim.size * p_dim.size]
 
         except BaseException:
+            if strict is True:
+                raise
             return False
 
         return True

--- a/pocean/dsg/profile/im.py
+++ b/pocean/dsg/profile/im.py
@@ -5,7 +5,7 @@ from collections import OrderedDict
 
 import numpy as np
 import pandas as pd
-import netCDF4 as nc4
+from cftime import date2num
 
 from pocean.utils import (
     create_ncvar_from_series,
@@ -115,7 +115,7 @@ class IncompleteMultidimensionalProfile(CFDataset):
             for i, (uid, pdf) in enumerate(profile_group):
                 profile[i] = uid
 
-                time[i] = nc4.date2num(pdf[axes.t].iloc[0], units=cls.default_time_unit)
+                time[i] = date2num(pdf[axes.t].iloc[0], units=cls.default_time_unit)
                 latitude[i] = pdf[axes.y].iloc[0]
                 longitude[i] = pdf[axes.x].iloc[0]
 

--- a/pocean/dsg/profile/om.py
+++ b/pocean/dsg/profile/om.py
@@ -34,7 +34,7 @@ class OrthogonalMultidimensionalProfile(CFDataset):
     """
 
     @classmethod
-    def is_mine(cls, dsg):
+    def is_mine(cls, dsg, strict=False):
         try:
             pvars = dsg.filter_by_attrs(cf_role='profile_id')
             assert len(pvars) == 1
@@ -90,6 +90,8 @@ class OrthogonalMultidimensionalProfile(CFDataset):
                     assert dv.size in [z_dim.size, p_dim.size, z_dim.size * p_dim.size]
 
         except BaseException:
+            if strict is True:
+                raise
             return False
 
         return True

--- a/pocean/dsg/timeseries/cr.py
+++ b/pocean/dsg/timeseries/cr.py
@@ -8,7 +8,7 @@ from pocean import logger  # noqa
 class ContiguousRaggedTimeseries(CFDataset):
 
     @classmethod
-    def is_mine(cls, dsg):
+    def is_mine(cls, dsg, strict=False):
         try:
             rvars = dsg.filter_by_attrs(cf_role='timeseries_id')
             assert len(rvars) == 1
@@ -30,6 +30,8 @@ class ContiguousRaggedTimeseries(CFDataset):
             # 2 = array of character arrays
             assert 0 <= len(rvar.dimensions) <= 2
         except AssertionError:
+            if strict is True:
+                raise
             return False
 
         return True

--- a/pocean/dsg/timeseries/im.py
+++ b/pocean/dsg/timeseries/im.py
@@ -8,7 +8,7 @@ from pocean import logger  # noqa
 class IncompleteMultidimensionalTimeseries(CFDataset):
 
     @classmethod
-    def is_mine(cls, dsg):
+    def is_mine(cls, dsg, strict=False):
         try:
             rvars = dsg.filter_by_attrs(cf_role='timeseries_id')
             assert len(rvars) == 1
@@ -39,6 +39,8 @@ class IncompleteMultidimensionalTimeseries(CFDataset):
             assert 0 <= len(rvar.dimensions) <= 2
 
         except AssertionError:
+            if strict is True:
+                raise
             return False
 
         return True

--- a/pocean/dsg/timeseries/ir.py
+++ b/pocean/dsg/timeseries/ir.py
@@ -8,7 +8,7 @@ from pocean import logger  # noqa
 class IndexedRaggedTimeseries(CFDataset):
 
     @classmethod
-    def is_mine(cls, dsg):
+    def is_mine(cls, dsg, strict=False):
         try:
             rvars = dsg.filter_by_attrs(cf_role='timeseries_id')
             assert len(rvars) == 1
@@ -31,6 +31,8 @@ class IndexedRaggedTimeseries(CFDataset):
             assert 0 <= len(rvar.dimensions) <= 2
 
         except AssertionError:
+            if strict is True:
+                raise
             return False
 
         return True

--- a/pocean/dsg/timeseries/om.py
+++ b/pocean/dsg/timeseries/om.py
@@ -5,7 +5,6 @@ from collections import OrderedDict
 
 import numpy as np
 import pandas as pd
-import netCDF4 as nc4
 
 from pocean.utils import (
     create_ncvar_from_series,

--- a/pocean/dsg/timeseriesProfile/im.py
+++ b/pocean/dsg/timeseriesProfile/im.py
@@ -6,7 +6,7 @@ from pocean.cf import CFDataset
 class IncompleteMultidimensionalTimeseriesProfile(CFDataset):
 
     @classmethod
-    def is_mine(cls, dsg):
+    def is_mine(cls, dsg, strict=False):
         try:
             assert dsg.featureType.lower() == 'timeseriesprofile'
             assert len(dsg.t_axes()) >= 1
@@ -29,6 +29,8 @@ class IncompleteMultidimensionalTimeseriesProfile(CFDataset):
             assert len(r_index_vars) == 0
 
         except AssertionError:
+            if strict is True:
+                raise
             return False
 
         return True

--- a/pocean/dsg/timeseriesProfile/om.py
+++ b/pocean/dsg/timeseriesProfile/om.py
@@ -5,7 +5,7 @@ from collections import OrderedDict
 
 import numpy as np
 import pandas as pd
-import netCDF4 as nc4
+from cftime import date2num
 
 from pocean.utils import (
     create_ncvar_from_series,
@@ -122,7 +122,7 @@ class OrthogonalMultidimensionalTimeseriesProfile(CFDataset):
             else:
                 nc.createDimension(axes.t, len(unique_t))
             time = nc.createVariable(axes.t, 'f8', (axes.t,))
-            time[:] = nc4.date2num(unique_t, units=cls.default_time_unit)
+            time[:] = date2num(unique_t, units=cls.default_time_unit)
 
             nc.createDimension(axes.z, unique_z.size)
             z = nc.createVariable(axes.z, get_dtype(unique_z), (axes.z,))

--- a/pocean/dsg/timeseriesProfile/om.py
+++ b/pocean/dsg/timeseriesProfile/om.py
@@ -27,7 +27,7 @@ from pocean import logger as L  # noqa
 class OrthogonalMultidimensionalTimeseriesProfile(CFDataset):
 
     @classmethod
-    def is_mine(cls, dsg):
+    def is_mine(cls, dsg, strict=False):
         try:
             assert dsg.featureType.lower() == 'timeseriesprofile'
             assert len(dsg.t_axes()) >= 1
@@ -57,6 +57,8 @@ class OrthogonalMultidimensionalTimeseriesProfile(CFDataset):
             assert len(r_index_vars) == 0
 
         except BaseException:
+            if strict is True:
+                raise
             return False
 
         return True

--- a/pocean/dsg/timeseriesProfile/r.py
+++ b/pocean/dsg/timeseriesProfile/r.py
@@ -8,7 +8,7 @@ from pocean.utils import logger  # noqa
 class RaggedTimeseriesProfile(CFDataset):
 
     @classmethod
-    def is_mine(cls, dsg):
+    def is_mine(cls, dsg, strict=False):
         try:
             assert dsg.featureType.lower() == 'timeseriesprofile'
             assert len(dsg.t_axes()) >= 1
@@ -34,6 +34,8 @@ class RaggedTimeseriesProfile(CFDataset):
                 assert r_index_vars[0].instance_dimension in dsg.dimensions  # Station dimension
 
         except AssertionError:
+            if strict is True:
+                raise
             return False
 
         return True

--- a/pocean/dsg/trajectory/im.py
+++ b/pocean/dsg/trajectory/im.py
@@ -6,7 +6,7 @@ from collections import OrderedDict
 import six
 import numpy as np
 import pandas as pd
-import netCDF4 as nc4
+from cftime import date2num
 
 from pocean.utils import (
     create_ncvar_from_series,
@@ -148,7 +148,7 @@ class IncompleteMultidimensionalTrajectory(CFDataset):
                 # tolist() converts to a python datetime object without timezone and has NaTs.
                 g = gdf[axes.t].tolist()
                 # date2num convers NaTs to np.nan
-                gg = nc4.date2num(g, units=cls.default_time_unit)
+                gg = date2num(g, units=cls.default_time_unit)
                 # masked_invalid moves np.nan to a masked value
                 time[ts(i, gg.size)] = np.ma.masked_invalid(gg)
 

--- a/pocean/dsg/trajectory/im.py
+++ b/pocean/dsg/trajectory/im.py
@@ -38,7 +38,7 @@ class IncompleteMultidimensionalTrajectory(CFDataset):
     """
 
     @classmethod
-    def is_mine(cls, dsg):
+    def is_mine(cls, dsg, strict=False):
         try:
             tvars = dsg.filter_by_attrs(cf_role='trajectory_id')
             assert len(tvars) == 1
@@ -96,6 +96,8 @@ class IncompleteMultidimensionalTrajectory(CFDataset):
                     assert dv.size == t_dim.size * o_dim.size
 
         except BaseException:
+            if strict is True:
+                raise
             return False
 
         return True

--- a/pocean/dsg/utils.py
+++ b/pocean/dsg/utils.py
@@ -1,5 +1,6 @@
 #!python
 # coding=utf-8
+from __future__ import division
 from datetime import datetime
 
 import pandas as pd

--- a/pocean/dsg/utils.py
+++ b/pocean/dsg/utils.py
@@ -1,0 +1,133 @@
+#!python
+# coding=utf-8
+from datetime import datetime
+
+import pandas as pd
+
+from pocean.utils import (
+    get_default_axes,
+    unique_justseen,
+)
+
+from pocean import logger as L  # noqa
+
+
+def get_geographic_attributes(df, axes=None):
+    axes = get_default_axes(axes)
+    miny = round(df[axes.y].min(), 5)
+    maxy = round(df[axes.y].max(), 5)
+    minx = round(df[axes.x].min(), 5)
+    maxx = round(df[axes.x].max(), 5)
+    polygon_wkt = 'POLYGON ((' \
+        '{maxy:.6f} {minx:.6f}, '  \
+        '{maxy:.6f} {maxx:.6f}, '  \
+        '{miny:.6f} {maxx:.6f}, '  \
+        '{miny:.6f} {minx:.6f}, '  \
+        '{maxy:.6f} {minx:.6f}'    \
+        '))'.format(
+            miny=miny,
+            maxy=maxy,
+            minx=minx,
+            maxx=maxx
+        )
+    return {
+        'variables': {
+            axes.y: {
+                'attributes': {
+                    'actual_min': miny,
+                    'actual_max': maxy,
+                }
+            },
+            axes.x: {
+                'attributes': {
+                    'actual_min': minx,
+                    'actual_max': maxx,
+                }
+            },
+        },
+        'attributes': {
+            'geospatial_lat_min': miny,
+            'geospatial_lat_max': maxy,
+            'geospatial_lon_min': minx,
+            'geospatial_lon_max': maxx,
+            'geospatial_bounds': polygon_wkt,
+            'geospatial_bounds_crs': 'EPSG:4326',
+        }
+    }
+
+
+def get_vertical_attributes(df, axes=None):
+    axes = get_default_axes(axes)
+
+    minz = round(df[axes.z].min(), 6)
+    maxz = round(df[axes.z].max(), 6)
+
+    return {
+        'variables': {
+            axes.z: {
+                'attributes': {
+                    'actual_min': minz,
+                    'actual_max': maxz,
+                }
+            },
+        },
+        'attributes': {
+            'geospatial_vertical_min': minz,
+            'geospatial_vertical_max': maxz,
+            'geospatial_vertical_units': 'm',
+        }
+    }
+
+
+def get_temporal_attributes(df, axes=None):
+    axes = get_default_axes(axes)
+    mint = df[axes.t].min()
+    maxt = df[axes.t].max()
+
+    times = pd.DatetimeIndex(unique_justseen(df[axes.t]))
+    dt_index_diff = times[1:] - times[:-1]
+    dt_counts = dt_index_diff.value_counts(sort=True)
+
+    if dt_counts.size > 0 and dt_counts.values[0] / (len(times) - 1) > 0.75:
+        mode_value = dt_counts.index[0]
+    else:
+        # Calculate a static resolution
+        mode_value = ((maxt - mint) / len(times))
+
+    return {
+        'variables': {
+            axes.t: {
+                'attributes': {
+                    'actual_min': mint.strftime('%Y-%m-%dT%H:%M:%SZ'),
+                    'actual_max': maxt.strftime('%Y-%m-%dT%H:%M:%SZ'),
+                }
+            },
+        },
+        'attributes': {
+            'time_coverage_start': mint.strftime('%Y-%m-%dT%H:%M:%SZ'),
+            'time_coverage_end': maxt.strftime('%Y-%m-%dT%H:%M:%SZ'),
+            'time_coverage_duration': (maxt - mint).round('1S').isoformat(),
+            'time_coverage_resolution': mode_value.round('1S').isoformat()
+        }
+    }
+
+
+def get_creation_attributes(df, history=None):
+    nc_create_ts = datetime.utcnow().strftime('%Y-%m-%dT%H:%M:%SZ')
+
+    attrs = {
+        'attributes': {
+            'date_created': nc_create_ts,
+            'date_issued': nc_create_ts,
+            'date_modified': nc_create_ts,
+        }
+    }
+
+    # Add in the passed in history
+    if history is not None:
+        attrs['attributes']['history'] = '{} - {}'.format(
+            nc_create_ts,
+            history
+        )
+
+    return attrs

--- a/pocean/meta.py
+++ b/pocean/meta.py
@@ -117,7 +117,7 @@ def ncpyattributes(obj, verbose=True):
         if isinstance(v, np.ndarray):
             newv = v.tolist()
         elif hasattr(v, 'dtype'):
-            newv = np.asscalar(v)
+            newv = v.item()
         else:
             newv = v
 

--- a/pocean/tests/dsg/test_utils.py
+++ b/pocean/tests/dsg/test_utils.py
@@ -1,0 +1,148 @@
+#!python
+# coding=utf-8
+import unittest
+from datetime import datetime, timedelta
+
+import pytz
+import pandas as pd
+from dateutil.parser import parse as dtparse
+
+from pocean.dsg import utils
+from pocean import logger as L  # noqa
+
+
+class TestDsgUtils(unittest.TestCase):
+
+    geo = pd.DataFrame({
+        'x': [-1, -2, -3, -4],
+        'y': [1, 2, 3, 4]
+    })
+
+    z = pd.DataFrame({
+        'z': [1, 2, 3, 4],
+    })
+
+    times = pd.DataFrame({
+        't': pd.to_datetime([
+            '2018-08-19 00:00:00',
+            '2018-08-20 00:00:00',
+            '2018-08-21 00:00:00',
+            '2018-08-22 00:00:00',
+            '2018-08-23 00:00:00',
+            '2018-08-23 00:00:05',
+        ])
+    })
+
+    avgtimes = pd.DataFrame({
+        't': pd.to_datetime([
+            '2018-08-19 00:00:00',
+            '2018-08-20 23:00:55',
+            '2018-08-21 00:00:35',
+        ])
+    })
+
+    def test_get_vertical_meta(self):
+        meta = utils.get_vertical_attributes(self.z)
+
+        assert meta == {
+            'variables': {
+                'z': {
+                    'attributes': {
+                        'actual_min': 1,
+                        'actual_max': 4,
+                    }
+                },
+            },
+            'attributes': {
+                'geospatial_vertical_min': 1,
+                'geospatial_vertical_max': 4,
+                'geospatial_vertical_units': 'm',
+            }
+        }
+
+    def test_get_geospatial_meta(self):
+        meta = utils.get_geographic_attributes(self.geo)
+
+        assert meta == {
+            'variables': {
+                'y': {
+                    'attributes': {
+                        'actual_min': 1,
+                        'actual_max': 4,
+                    }
+                },
+                'x': {
+                    'attributes': {
+                        'actual_min': -4,
+                        'actual_max': -1,
+                    }
+                },
+            },
+            'attributes': {
+                'geospatial_lat_max': 4,
+                'geospatial_lat_min': 1,
+                'geospatial_lon_max': -1,
+                'geospatial_lon_min': -4,
+                'geospatial_bounds': (
+                    'POLYGON (('
+                    '4.000000 -4.000000, '
+                    '4.000000 -1.000000, '
+                    '1.000000 -1.000000, '
+                    '1.000000 -4.000000, '
+                    '4.000000 -4.000000'
+                    '))'
+                ),
+                'geospatial_bounds_crs': 'EPSG:4326',
+            }
+        }
+
+    def test_get_temporal_meta_from_times_average(self):
+        meta = utils.get_temporal_attributes(self.avgtimes)
+
+        assert meta == {
+            'variables': {
+                't': {
+                    'attributes': {
+                        'actual_min': '2018-08-19T00:00:00Z',
+                        'actual_max': '2018-08-21T00:00:35Z',
+                    }
+                }
+            },
+            'attributes': {
+                'time_coverage_start': '2018-08-19T00:00:00Z',
+                'time_coverage_end': '2018-08-21T00:00:35Z',
+                'time_coverage_duration': 'P2DT0H0M35S',
+                'time_coverage_resolution': 'P0DT16H0M12S',
+            }
+        }
+
+    def test_get_temporal_meta_from_times(self):
+        meta = utils.get_temporal_attributes(self.times)
+
+        assert meta == {
+            'variables': {
+                't': {
+                    'attributes': {
+                        'actual_min': '2018-08-19T00:00:00Z',
+                        'actual_max': '2018-08-23T00:00:05Z',
+                    }
+                }
+            },
+            'attributes': {
+                'time_coverage_start': '2018-08-19T00:00:00Z',
+                'time_coverage_end': '2018-08-23T00:00:05Z',
+                'time_coverage_duration': 'P4DT0H0M5S',
+                'time_coverage_resolution': 'P1DT0H0M0S',
+            }
+        }
+
+    def test_get_creation(self):
+        # We pass in the df just to standardize on the metadata functions... it isn't used.
+        meta = utils.get_creation_attributes(self.times, history='DID THINGS')
+
+        now = datetime.utcnow().replace(tzinfo=pytz.utc)
+
+        assert (now - dtparse(meta['attributes']['date_created'])) < timedelta(minutes=1)
+        assert (now - dtparse(meta['attributes']['date_issued'])) < timedelta(minutes=1)
+        assert (now - dtparse(meta['attributes']['date_modified'])) < timedelta(minutes=1)
+        assert 'DID THINGS' in meta['attributes']['history']

--- a/pocean/tests/dsg/timeseries/test_timeseries_om.py
+++ b/pocean/tests/dsg/timeseries/test_timeseries_om.py
@@ -4,6 +4,8 @@ import os
 import tempfile
 import unittest
 
+import numpy as np
+
 from pocean.dsg import OrthogonalMultidimensionalTimeseries
 from pocean.tests.dsg.test_new import test_is_mine
 
@@ -17,27 +19,91 @@ class TestOrthogonalMultidimensionalTimeseries(unittest.TestCase):
 
     def setUp(self):
         self.single = os.path.join(os.path.dirname(__file__), 'resources', 'tt.nc')
+        self.ph = np.ma.array([
+            8.1080176, 8.11740265, 8.11924184, 8.11615471, 8.11445695, 8.11600021,
+            8.11903291, 8.1187229, 8.105218, 8.10998784, 8.10715445, 8.10530323,
+            8.11167052, 8.11142766, 8.10897461, 8.08827717, 8.11343609, 8.11746859,
+            8.12326458, 8.11770947, 8.09127117, 8.10770576, 8.10252467, 8.10252874
+        ])
 
     def test_omp_load(self):
         OrthogonalMultidimensionalTimeseries(self.single).close()
 
-    def test_timeseries_omp_dataframe(self):
+    def test_timeseries_omt_dataframe(self):
         fid, single_tmp = tempfile.mkstemp(suffix='.nc')
         with OrthogonalMultidimensionalTimeseries(self.single) as s:
             df = s.to_dataframe()
             with OrthogonalMultidimensionalTimeseries.from_dataframe(df, single_tmp) as result_ncd:
                 assert 'station' in result_ncd.dimensions
+                assert np.ma.allclose(
+                    result_ncd.variables['pH'][:].flatten(),
+                    self.ph
+                )
         test_is_mine(OrthogonalMultidimensionalTimeseries, single_tmp)  # Try to load it again
         os.close(fid)
         os.remove(single_tmp)
 
-    # def test_omp_calculated_metadata(self):
-    #     with OrthogonalMultidimensionalTimeseries(self.single) as ncd:
-    #         s = ncd.calculated_metadata()
-    #         assert s.min_t == dtparse('2005-07-09 01:48:00')
-    #         assert s.max_t == dtparse('2005-07-09 01:48:00')
-    #         assert np.isclose(s.profiles[1].min_z, 0.)
-    #         assert np.isclose(s.profiles[1].max_z, 96.06)
-    #         assert s.profiles[1].t == dtparse('2005-07-09 01:48:00')
-    #         assert np.isclose(s.profiles[1].x, -149.3582)
-    #         assert np.isclose(s.profiles[1].y, 60.0248)
+    def test_timeseries_omt_reduce_dims(self):
+        fid, single_tmp = tempfile.mkstemp(suffix='.nc')
+        with OrthogonalMultidimensionalTimeseries(self.single) as s:
+            df = s.to_dataframe()
+            with OrthogonalMultidimensionalTimeseries.from_dataframe(
+                df,
+                single_tmp,
+                reduce_dims=True
+            ) as result_ncd:
+                assert 'station' not in result_ncd.dimensions
+                assert np.ma.allclose(
+                    result_ncd.variables['pH'][:].flatten(),
+                    self.ph
+                )
+        test_is_mine(OrthogonalMultidimensionalTimeseries, single_tmp)  # Try to load it again
+        os.close(fid)
+        os.remove(single_tmp)
+
+    def test_timeseries_omt_no_z(self):
+        fid, single_tmp = tempfile.mkstemp(suffix='.nc')
+        with OrthogonalMultidimensionalTimeseries(self.single) as s:
+            df = s.to_dataframe()
+            axes = {
+                'z': None
+            }
+            df.drop(columns=['z'], inplace=True)
+            with OrthogonalMultidimensionalTimeseries.from_dataframe(
+                df,
+                single_tmp,
+                axes=axes,
+            ) as result_ncd:
+                assert 'station' in result_ncd.dimensions
+                assert 'z' not in result_ncd.variables
+                assert np.ma.allclose(
+                    result_ncd.variables['pH'][:].flatten(),
+                    self.ph
+                )
+        test_is_mine(OrthogonalMultidimensionalTimeseries, single_tmp)  # Try to load it again
+        os.close(fid)
+        os.remove(single_tmp)
+
+    def test_timeseries_omt_no_z_no_station(self):
+        fid, single_tmp = tempfile.mkstemp(suffix='.nc')
+        with OrthogonalMultidimensionalTimeseries(self.single) as s:
+            df = s.to_dataframe()
+            axes = {
+                'z': None
+            }
+            df.drop(columns=['z'], inplace=True)
+            with OrthogonalMultidimensionalTimeseries.from_dataframe(
+                df,
+                single_tmp,
+                axes=axes,
+                reduce_dims=True
+            ) as result_ncd:
+                assert 'station' not in result_ncd.dimensions
+                assert 'z' not in result_ncd.variables
+                assert np.ma.allclose(
+                    result_ncd.variables['pH'][:].flatten(),
+                    self.ph
+                )
+        test_is_mine(OrthogonalMultidimensionalTimeseries, single_tmp)  # Try to load it again
+        os.close(fid)
+        os.remove(single_tmp)

--- a/pocean/tests/test_cf.py
+++ b/pocean/tests/test_cf.py
@@ -1,0 +1,19 @@
+#!python
+# coding=utf-8
+import unittest
+
+from pocean.cf import CFDataset
+from pocean.dsg import OrthogonalMultidimensionalTimeseries as omt
+
+import logging
+from pocean import logger as L
+L.level = logging.INFO
+L.handlers = [logging.StreamHandler()]
+
+
+class TestCFDatasetLoad(unittest.TestCase):
+
+    def test_load_url(self):
+        ncd = CFDataset.load('http://geoport.whoi.edu/thredds/dodsC/usgs/data2/emontgomery/stellwagen/CF-1.6/ARGO_MERCHANT/1211-AA.cdf')
+        assert omt.is_mine(ncd) is True
+        ncd.close()

--- a/pocean/tests/test_cf.py
+++ b/pocean/tests/test_cf.py
@@ -1,5 +1,6 @@
 #!python
 # coding=utf-8
+import os
 import unittest
 
 from pocean.cf import CFDataset
@@ -16,4 +17,13 @@ class TestCFDatasetLoad(unittest.TestCase):
     def test_load_url(self):
         ncd = CFDataset.load('http://geoport.whoi.edu/thredds/dodsC/usgs/data2/emontgomery/stellwagen/CF-1.6/ARGO_MERCHANT/1211-AA.cdf')
         assert omt.is_mine(ncd) is True
+        ncd.close()
+
+    def test_load_strict(self):
+        ncfile = os.path.join(os.path.dirname(__file__), 'dsg', 'profile', 'resources', 'om-single.nc')
+
+        ncd = CFDataset.load(ncfile)
+        assert omt.is_mine(ncd) is False
+        with self.assertRaises(BaseException):
+            omt.is_mine(ncd, strict=True)
         ncd.close()

--- a/pocean/tests/test_nc.py
+++ b/pocean/tests/test_nc.py
@@ -141,24 +141,26 @@ class TestJsonDataset(unittest.TestCase):
             meta = cfncd.json(return_data=True, fill_data=False)
             jsdata = meta['variables']['data1']['data']
             npt.assert_array_equal(ncdata, jsdata)
-
-            with tempfile.NamedTemporaryFile() as f:
-                with CFDataset(f.name, 'w') as newcf:
-                    newcf.apply_json(meta)
-
-                with CFDataset(f.name, 'r') as rcf:
-                    newncdata = rcf.variables['data1'][:]
-                    npt.assert_array_equal(ncdata, newncdata)
+            fhandle1, fname1 = tempfile.mkstemp()
+            with CFDataset(fname1, 'w') as newcf:
+                newcf.apply_json(meta)
+            with CFDataset(fname1, 'r') as rcf:
+                newncdata = rcf.variables['data1'][:]
+                npt.assert_array_equal(ncdata, newncdata)
+            os.close(fhandle1)
+            os.remove(fname1)
 
             # Filled
             meta = cfncd.json(return_data=True, fill_data=True)
             jsdata = meta['variables']['data1']['data']
             npt.assert_array_equal(ncdata, jsdata)
+            fhandle2, fname2 = tempfile.mkstemp()
+            with CFDataset(fname2, 'w') as newcf:
+                newcf.apply_json(meta)
 
-            with tempfile.NamedTemporaryFile() as f:
-                with CFDataset(f.name, 'w') as newcf:
-                    newcf.apply_json(meta)
+            with CFDataset(fname2, 'r') as rcf:
+                newncdata = rcf.variables['data1'][:]
+                npt.assert_array_equal(ncdata, newncdata)
 
-                with CFDataset(f.name, 'r') as rcf:
-                    newncdata = rcf.variables['data1'][:]
-                    npt.assert_array_equal(ncdata, newncdata)
+            os.close(fhandle2)
+            os.remove(fname2)

--- a/pocean/utils.py
+++ b/pocean/utils.py
@@ -9,6 +9,12 @@ import simplejson as json
 from datetime import datetime, date, time
 from collections import namedtuple, Mapping, Counter
 
+try:
+    # PY2 support
+    from urlparse import urlparse as uparse
+except ImportError:
+    from urllib.parse import urlparse as uparse
+
 import pandas as pd
 import numpy as np
 import netCDF4 as nc4
@@ -22,6 +28,14 @@ def downcast_dataframe(df):
         if np.issubdtype(df[column].dtype, np.int64):
             df[column] = df[column].astype(np.int32)
     return df
+
+
+def is_url(url):
+    try:
+        result = uparse(url)
+        return all([result.scheme, result.netloc])
+    except ValueError:
+        return False
 
 
 def namedtuple_with_defaults(typename, field_names, default_values=()):

--- a/pocean/utils.py
+++ b/pocean/utils.py
@@ -18,6 +18,7 @@ except ImportError:
 import pandas as pd
 import numpy as np
 import netCDF4 as nc4
+from cftime import num2date, date2num
 
 from . import logger
 L = logger
@@ -287,7 +288,7 @@ def get_ncdata_from_series(series, ncvar, fillna=True):
     if np.issubdtype(series.dtype, np.datetime64):
         units = getattr(ncvar, 'units', CFDataset.default_time_unit)
         calendar = getattr(ncvar, 'calendar', 'standard')
-        nums = nc4.date2num(series.tolist(), units=units, calendar=calendar)
+        nums = date2num(series.tolist(), units=units, calendar=calendar)
         return np.ma.masked_invalid(nums)
     else:
         if fillna is True:
@@ -302,7 +303,7 @@ def get_masked_datetime_array(t, tvar, mask_nan=True):
     if isinstance(t, np.ma.core.MaskedConstant):
         return t
     elif np.isscalar(t):
-        return nc4.num2date(t, tvar.units, getattr(tvar, 'calendar', 'standard'))
+        return num2date(t, tvar.units, getattr(tvar, 'calendar', 'standard'))
 
     if mask_nan is True:
         t = np.ma.masked_invalid(t)
@@ -310,11 +311,11 @@ def get_masked_datetime_array(t, tvar, mask_nan=True):
     t_cal = getattr(tvar, 'calendar', 'standard')
 
     # Get the min value we can have and mask anything else
-    # This is limied by **python** datetime objects and not
+    # This is limited by **python** datetime objects and not
     # nc4 objects. The min nc4 datetime object is
     # min_date = nc4.netcdftime.datetime(-4713, 1, 1, 12, 0, 0, 40)
     # There is no max date for nc4.
-    min_nums = nc4.date2num([datetime.min, datetime.max], tvar.units, t_cal)
+    min_nums = date2num([datetime.min, datetime.max], tvar.units, t_cal)
     t = np.ma.masked_outside(t, *min_nums)
     # Avoid deprecation warnings between numpy 1.11 and 1.14
     # After 1.14 this is the default behavior
@@ -323,7 +324,7 @@ def get_masked_datetime_array(t, tvar, mask_nan=True):
     t_mask = np.copy(np.ma.getmaskarray(t))
     t[t_mask] = 1
 
-    dts = nc4.num2date(t, tvar.units, t_cal)
+    dts = num2date(t, tvar.units, t_cal)
     if isinstance(dts, datetime):
         dts = np.array([dts.isoformat()], dtype='datetime64')
 

--- a/pocean/utils.py
+++ b/pocean/utils.py
@@ -86,7 +86,7 @@ def all_subclasses(cls, skips=None):
     if skips is None:
         skips = []
 
-    for subclass in cls.__subclasses__():
+    for subclass in list(set(cls.__subclasses__())):
         if subclass not in skips:
             yield subclass
         for subc in all_subclasses(subclass):

--- a/pocean/utils.py
+++ b/pocean/utils.py
@@ -228,7 +228,7 @@ def generic_masked(arr, attrs=None, minv=None, maxv=None, mask_nan=True):
 
 
 def pyscalar(val):
-    return np.asscalar(val)
+    return val.item()
 
 
 def get_fill_value(var):
@@ -448,7 +448,7 @@ class JSONEncoder(json.JSONEncoder):
         if isinstance(obj, np.ndarray):
             return obj.tolist()
         elif isinstance(obj, np.generic):
-            return np.asscalar(obj)
+            return obj.item()
         elif isinstance(obj, pd.Timestamp):
             return obj.to_pydatetime().isoformat()
         elif isinstance(obj, (datetime, date, time)):

--- a/pytest.ini
+++ b/pytest.ini
@@ -4,7 +4,11 @@ addopts = -s -rxs -v
 
 flake8-max-line-length = 100
 flake8-ignore =
-    *.py E265 E501 E221 E203 E201 E124 E202 E241 E251 W293 W291
+    *.py E265 E501 E221 E203 E201 E124 E202 E241 E251 W293 W291 W504
     docs/* ALL
     pocean/tests/*.py F403 F405
     pocean/tests/*.py F403 F405
+
+filterwarnings =
+    ignore::DeprecationWarning
+    ignore::UserWarning

--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -1,0 +1,2 @@
+pytest
+pytest-flake8

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,10 +1,10 @@
 netcdf4
 numpy>=1.14
-pandas>=0.21.0
+pandas>=0.24,<0.25
 pygc>=1.2.0
 python-dateutil
 pytz
 shapely
 simplejson
 six
-cftime==1.0.1  # tempfix for real_datetime issue
+cftime


### PR DESCRIPTION
* Bumping pandas to 0.24 for all of the timestamp/timezone changes
* Added support for reading from DAP urls
* Add the `strict=True` option for all `is_mine` calls to raise the error as to **why** the dataset wasn't compliant.
* Move to flake8
* Import `date2num` and `num2date` from `cftime`
* Add some generic metadata helpers for DSG classes, based on a dataframe