### PR TITLE
use numpy >=1.20

### DIFF
--- a/pocean/utils.py
+++ b/pocean/utils.py
@@ -274,7 +274,7 @@ def create_ncvar_from_series(ncd, var_name, dimensions, series, **kwargs):
     elif series.dtype.kind in ['U', 'S'] or series.dtype in [str]:
         # AttributeError: cannot set _FillValue attribute for VLEN or compound variable
         v = ncd.createVariable(var_name, get_dtype(series), dimensions, **kwargs)
-    elif series.dtype == np.object:
+    elif series.dtype == object:
         # Try to downcast to an int and then just take the type of the result
         # If we can't convert to a numeric use a string
         try:

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 cftime>=1.2.1
 netcdf4
-numpy>=1.15
+numpy>=1.20
 pandas>=1.0.5
 python-dateutil
 pytz

--- a/setup.cfg
+++ b/setup.cfg
@@ -30,7 +30,7 @@ packages = find:
 install_requires =
     cftime>=1.2.1
     netcdf4
-    numpy>=1.15
+    numpy>=1.20
     pandas>=1.0.5
     python-dateutil
     pytz


### PR DESCRIPTION
The `np.object`, and many other aliases, as deprecated and removed in numpy 1.24. This updates the code and set a new min numpy version.

@kwilcox I'd appreciate if we can merge this quick and issue a new release. I can take care of the latter.