### PR TITLE
Updates

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@ output/*
 *.swp
 build/*
 dist/*
+resources/
 *.egg-info*
 .cache
 docs/api

--- a/docs/development.rst
+++ b/docs/development.rst
@@ -13,4 +13,9 @@ Running tests
 
 .. code-block:: bash
 
+    # download test datasets
+    cd pocean/tests
+    python download_test_data.py
+
+    # run test suite
     pytest

--- a/pocean/dsg/trajectory/im.py
+++ b/pocean/dsg/trajectory/im.py
@@ -136,7 +136,13 @@ class IncompleteMultidimensionalTrajectory(CFDataset):
                 def ts(t_index, size):
                     return np.s_[0:size]
                 default_dimensions = (daxes.sample,)
-                trajectory = nc.createVariable(axes.trajectory, get_dtype(df[axes.trajectory]))
+                # To support the IOOS netCDF specification, if traj_strlen is specified
+                # use a char array for the trajectory variable with a dimension traj_strlen.
+                if 'traj_strlen' in kwargs:
+                    nc.createDimension('traj_strlen', kwargs['traj_strlen'])
+                    trajectory = nc.createVariable(axes.trajectory, 'S1', ('traj_strlen',))
+                else:
+                    trajectory = nc.createVariable(axes.trajectory, get_dtype(df[axes.trajectory]))
             else:
                 def ts(t_index, size):
                     return np.s_[t_index, 0:size]

--- a/pocean/dsg/utils.py
+++ b/pocean/dsg/utils.py
@@ -175,8 +175,8 @@ def get_temporal_attributes(df, axes=None):
         'attributes': {
             'time_coverage_start': mint.strftime('%Y-%m-%dT%H:%M:%SZ'),
             'time_coverage_end': maxt.strftime('%Y-%m-%dT%H:%M:%SZ'),
-            'time_coverage_duration': (maxt - mint).round('1S').isoformat(),
-            'time_coverage_resolution': mode_value.round('1S').isoformat()
+            'time_coverage_duration': (maxt - mint).round('1s').isoformat(),
+            'time_coverage_resolution': mode_value.round('1s').isoformat()
         }
     }
 

--- a/pocean/tests/dsg/trajectory/test_trajectory_im.py
+++ b/pocean/tests/dsg/trajectory/test_trajectory_im.py
@@ -158,13 +158,13 @@ class TestIncompleteMultidimensionalTrajectory(unittest.TestCase):
 
         with IncompleteMultidimensionalTrajectory(filepath) as ncd:
             s = ncd.calculated_metadata()
-            assert s.min_t.round('S') == dtparse('1990-01-01 00:00:00')
-            assert s.max_t.round('S') == dtparse('1990-01-05 03:00:00')
+            assert s.min_t.round('s') == dtparse('1990-01-01 00:00:00')
+            assert s.max_t.round('s') == dtparse('1990-01-05 03:00:00')
             traj1 = s.trajectories["Trajectory1"]
             assert traj1.min_z == 0
             assert traj1.max_z == 99
-            assert traj1.min_t.round('S') == dtparse('1990-01-01 00:00:00')
-            assert traj1.max_t.round('S') == dtparse('1990-01-05 03:00:00')
+            assert traj1.min_t.round('s') == dtparse('1990-01-01 00:00:00')
+            assert traj1.max_t.round('s') == dtparse('1990-01-05 03:00:00')
             first_loc = traj1.geometry.coords[0]
             assert np.isclose(first_loc[0], -7.9336)
             assert np.isclose(first_loc[1], 42.00339)
@@ -180,8 +180,8 @@ class TestIncompleteMultidimensionalTrajectory(unittest.TestCase):
             traj0 = m.trajectories["Trajectory0"]
             assert traj0.min_z == 0
             assert traj0.max_z == 35
-            assert traj0.min_t.round('S') == dtparse('1990-01-01 00:00:00')
-            assert traj0.max_t.round('S') == dtparse('1990-01-02 11:00:00')
+            assert traj0.min_t.round('s') == dtparse('1990-01-01 00:00:00')
+            assert traj0.max_t.round('s') == dtparse('1990-01-02 11:00:00')
             first_loc = traj0.geometry.coords[0]
             assert np.isclose(first_loc[0], -35.07884)
             assert np.isclose(first_loc[1], 2.15286)
@@ -189,8 +189,8 @@ class TestIncompleteMultidimensionalTrajectory(unittest.TestCase):
             traj3 = m.trajectories["Trajectory3"]
             assert traj3.min_z == 0
             assert traj3.max_z == 36
-            assert traj3.min_t.round('S') == dtparse('1990-01-01 00:00:00')
-            assert traj3.max_t.round('S') == dtparse('1990-01-02 12:00:00')
+            assert traj3.min_t.round('s') == dtparse('1990-01-01 00:00:00')
+            assert traj3.max_t.round('s') == dtparse('1990-01-02 12:00:00')
             first_loc = traj3.geometry.coords[0]
             assert np.isclose(first_loc[0], -73.3026)
             assert np.isclose(first_loc[1], 1.95761)

--- a/pocean/tests/dsg/trajectoryProfile/test_trajectoryProfile_cr.py
+++ b/pocean/tests/dsg/trajectoryProfile/test_trajectoryProfile_cr.py
@@ -107,14 +107,14 @@ class TestContinousRaggedTrajectoryProfile(unittest.TestCase):
 
         with ContiguousRaggedTrajectoryProfile(self.single) as st:
             s = st.calculated_metadata(axes=axes)
-            assert s.min_t.round('S') == dtparse('2014-11-25 18:57:30')
-            assert s.max_t.round('S') == dtparse('2014-11-27 07:10:30')
+            assert s.min_t.round('s') == dtparse('2014-11-25 18:57:30')
+            assert s.max_t.round('s') == dtparse('2014-11-27 07:10:30')
             assert len(s.trajectories) == 1
             traj = s.trajectories["sp025-20141125T1730"]
             assert traj.min_z == 0
             assert np.isclose(traj.max_z, 504.37827)
-            assert traj.min_t.round('S') == dtparse('2014-11-25 18:57:30')
-            assert traj.max_t.round('S') == dtparse('2014-11-27 07:10:30')
+            assert traj.min_t.round('s') == dtparse('2014-11-25 18:57:30')
+            assert traj.max_t.round('s') == dtparse('2014-11-27 07:10:30')
 
             first_loc = traj.geometry.coords[0]
             assert np.isclose(first_loc[0], -119.79025)
@@ -131,20 +131,20 @@ class TestContinousRaggedTrajectoryProfile(unittest.TestCase):
 
         with ContiguousRaggedTrajectoryProfile(self.multi) as mt:
             m = mt.calculated_metadata(axes=axes)
-            assert m.min_t.round('S') == dtparse('1990-01-01 00:00:00')
-            assert m.max_t.round('S') == dtparse('1990-01-03 02:00:00')
+            assert m.min_t.round('s') == dtparse('1990-01-01 00:00:00')
+            assert m.max_t.round('s') == dtparse('1990-01-03 02:00:00')
             assert len(m.trajectories) == 5
             # First trajectory
             traj0 = m.trajectories[0]
             assert traj0.min_z == 0
             assert traj0.max_z == 43
-            assert traj0.min_t.round('S') == dtparse('1990-01-02 05:00:00')
-            assert traj0.max_t.round('S') == dtparse('1990-01-03 01:00:00')
+            assert traj0.min_t.round('s') == dtparse('1990-01-02 05:00:00')
+            assert traj0.max_t.round('s') == dtparse('1990-01-03 01:00:00')
             first_loc = traj0.geometry.coords[0]
             assert first_loc[0] == -60
             assert first_loc[1] == 53
             assert len(traj0.profiles) == 4
-            assert traj0.profiles[0].t.round('S') == dtparse('1990-01-03 01:00:00')
+            assert traj0.profiles[0].t.round('s') == dtparse('1990-01-03 01:00:00')
             assert traj0.profiles[0].x == -60
             assert traj0.profiles[0].y == 49
 
@@ -152,13 +152,13 @@ class TestContinousRaggedTrajectoryProfile(unittest.TestCase):
             traj4 = m.trajectories[4]
             assert traj4.min_z == 0
             assert traj4.max_z == 38
-            assert traj4.min_t.round('S') == dtparse('1990-01-02 14:00:00')
-            assert traj4.max_t.round('S') == dtparse('1990-01-02 15:00:00')
+            assert traj4.min_t.round('s') == dtparse('1990-01-02 14:00:00')
+            assert traj4.max_t.round('s') == dtparse('1990-01-02 15:00:00')
             first_loc = traj4.geometry.coords[0]
             assert first_loc[0] == -67
             assert first_loc[1] == 47
             assert len(traj4.profiles) == 4
-            assert traj4.profiles[19].t.round('S') == dtparse('1990-01-02 14:00:00')
+            assert traj4.profiles[19].t.round('s') == dtparse('1990-01-02 14:00:00')
             assert traj4.profiles[19].x == -44
             assert traj4.profiles[19].y == 47
 


### PR DESCRIPTION
 * Support gliderdac:3.0
 * Ignore resources directories for testing
 * pytest fixes
   * Data files for testing are now downloaded separately using pooch
   * Change 'S' to 's' to eliminate pytest warnings
* Update im.py: Remove breakpoint

Initial contribution towards #86 