### PR TITLE
~~Fix warnings~~ Fix numpy 2.0 failures

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,3 +9,7 @@ updates:
       interval: "daily"
     labels:
       - "Bot"
+    groups:
+      github-actions:
+        patterns:
+          - '*'

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        python-version: ["3.8", "3.9", "3.10", "3.11", "3.12"]
+        python-version: [ "3.8", "3.9", "3.10", "3.11", "3.12" ]
         os: [windows-latest, ubuntu-latest, macos-latest]
       fail-fast: false
 

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -18,7 +18,7 @@ repos:
         - requirements-dev.txt
 
 - repo: https://github.com/astral-sh/ruff-pre-commit
-  rev: v0.4.8
+  rev: v0.4.9
   hooks:
     - id: ruff
 

--- a/pocean/dsg/trajectoryProfile/cr.py
+++ b/pocean/dsg/trajectoryProfile/cr.py
@@ -20,6 +20,7 @@ from pocean.utils import (
     get_ncdata_from_series,
     nativize_times,
     normalize_countable_array,
+    upscale_int8,
 )
 
 
@@ -323,6 +324,7 @@ class ContiguousRaggedTrajectoryProfile(CFDataset):
             df_data[dnam] = vdata
 
         df = pd.DataFrame(df_data)
+        df = upscale_int8(df)
 
         # Drop all data columns with no data
         if clean_cols:

--- a/pocean/tests/test_utils.py
+++ b/pocean/tests/test_utils.py
@@ -138,7 +138,7 @@ class TestUtils(unittest.TestCase):
             # to make sure it doesn't error
             b = ncd.createVariable('imabyte', 'b')
             b.valid_min = 0
-            b.valid_max = 600  # this is over a byte and thus invalid
+            b.valid_max = np.int16(600)  # this is over a byte and thus invalid
             b[:] = 3
             r = generic_masked(b[:], attrs=ncd.vatts(b.name))
             assert np.all(r.mask == False)  # noqa

--- a/pocean/tests/test_utils.py
+++ b/pocean/tests/test_utils.py
@@ -203,7 +203,7 @@ class TestNormalizeArray(unittest.TestCase):
 
             # Single str (no dimension)
             ncd.createVariable('single_str', str)
-            ncd.createVariable('single_unicode_', np.unicode_)
+            ncd.createVariable('single_unicode_', np.str_)
             ncd.createVariable('single_U', '<U1')
             ncd.createVariable('single_S', 'S1', ('n',))
 
@@ -216,7 +216,7 @@ class TestNormalizeArray(unittest.TestCase):
 
             # Array of str
             ncd.createVariable('many_str', str, ('n',))
-            ncd.createVariable('many_unicode_', np.unicode_, ('n',))
+            ncd.createVariable('many_unicode_', np.str_, ('n',))
             ncd.createVariable('many_U', '<U1', ('n',))
             ncd.createVariable('many_S', 'S1', ('n', 'n',))
 

--- a/pocean/utils.py
+++ b/pocean/utils.py
@@ -458,6 +458,13 @@ def dict_update(d, u):
     return d
 
 
+def upscale_int8(df):
+    """Numpy 2.0 no linger upcast dtypes.
+    In order to preserve the data's original dtype we upcast it here after reading it.
+
+    """
+    return df.astype({col: "int16" for col in df.columns[df.dtypes == "int8"]})
+
 class JSONEncoder(json.JSONEncoder):
 
     def default(self, obj):


### PR DESCRIPTION
Numpy no longer upcasts dtypes, we can:

1. Let the original data be and upcast here in pocean, implemented in this PR;
2. Error out and ask people to fix the data.

I prefer 1 but we can revert this change if other disagree,