### PR TITLE
Don't hardcode fill_value

### DIFF
--- a/pocean/cf.py
+++ b/pocean/cf.py
@@ -11,7 +11,7 @@ from .utils import all_subclasses, is_url
 
 class CFDataset(EnhancedDataset):
 
-    default_fill_value = -9999.9
+    default_fill_value = False
     default_time_unit = 'seconds since 1990-01-01 00:00:00Z'
 
     @classmethod


### PR DESCRIPTION
Instead of using a float value and relying on old numpy's behavior we will use netCDF4's default fill values:

```
{'S1': '\x00',
 'i1': -127,
 'u1': 255,
 'i2': -32767,
 'u2': 65535,
 'i4': -2147483647,
 'u4': 4294967295,
 'i8': -9223372036854775806,
 'u8': 18446744073709551614,
 'f4': 9.969209968386869e+36,
 'f8': 9.969209968386869e+36,
 'c8': 9.969209968386869e+36,
 'c16': 9.969209968386869e+36}
```

This will make pocean-core really numpy 2.0 compliant, even though we didn't catch this one in the tests, and make the data saved smaller and "more consistent" in same cases as the original dtype will be using for the fill value.